### PR TITLE
Add Eta support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .stack-work
+dist
 *#
 *~

--- a/kademlia.cabal
+++ b/kademlia.cabal
@@ -51,7 +51,7 @@ library
                      , memory
                      , MonadRandom
                      , mtl                 >= 2.1.3.1
-                     , network             >= 2.8 && < 2.9
+                     , network             >= 2.6 && < 2.9
                      , random
                      , random-shuffle
                      , stm                 >= 2.4.3
@@ -69,5 +69,3 @@ library
                         GeneralizedNewtypeDeriving
                         OverloadedStrings
                         RecordWildCards
-                        TypeApplications
-


### PR DESCRIPTION
- This library doesn't actually use the `TypeApplications` extension and builds fine without it.
- Eta currently only has a patch for `network-2.6.3.2` and it built fine, so I relaxed the lower bound on `network`.
- Added `dist` to the gitignore because that's where Etlas (and Cabal) build info is stored.