### PR TITLE
Update Stackage LTS to match Coda version

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-8.5
+resolver: lts-13.7
 packages:
 - '.'
 nix:


### PR DESCRIPTION
Before Rahul Mutt's change it didn't actually compile with stack build since network 2.8 is not in LTS 8.5. After Rahul's change it does compile, but the Stackage versions should match regardless.